### PR TITLE
 Implement Protected Route Wrapper for Authentication

### DIFF
--- a/src/components/ProtectedPageWrapper.tsx
+++ b/src/components/ProtectedPageWrapper.tsx
@@ -1,0 +1,31 @@
+
+// src/components/ProtectedPageWrapper.tsx
+'use client';
+
+import { useUser } from '@/context/userContext';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface ProtectedPageWrapperProps {
+  children: React.ReactNode;
+}
+
+const ProtectedPageWrapper: React.FC<ProtectedPageWrapperProps> = ({ children }) => {
+  const { user } = useUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    // If the user is not authenticated, redirect to the login page
+    if (!user.isAuthenticated) {
+      router.push('/login');
+    }
+  }, [user, router]);
+
+  if (!user.isAuthenticated) {
+    return null; // Return null while redirecting to avoid rendering the page content
+  }
+
+  return <>{children}</>; // Only render the protected content if the user is authenticated
+};
+
+export default ProtectedPageWrapper;

--- a/src/components/ProtectedRoute.js
+++ b/src/components/ProtectedRoute.js
@@ -1,0 +1,18 @@
+import { useAuth } from '@/lib/AuthContext';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+const ProtectedRoute = ({ children }) => {
+    const { user } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (!user) {
+            router.push('/login'); // Redirect to login if not authenticated
+        }
+    }, [user, router]);
+
+    return user ? children : null; // Render children if authenticated
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
Created ProtectedPageWrapper component to restrict access to authenticated users.
Integrated useUser context to check authentication status.
Redirects unauthenticated users to the login page using useRouter.
Prevents rendering protected content while redirecting.
Ensures only authenticated users can access protected pages.